### PR TITLE
Fixed avatar so it does not transform into an oval shape in some cases

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -183,6 +183,8 @@ a.btn-back {
 .author-avatar img {
     width: 100px;
     height: 100px;
+    max-width: 100px;
+    max-height: 100px;
     border-radius: 50px;
 }
 


### PR DESCRIPTION
I noticed that while resizing the browser the avatar circle at the bottom would sometimes be slightly oval. This fixes that.
