### PR TITLE
Added 15px of padding so social icons are not flush against the bottom o...

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -28,6 +28,7 @@ main {
 .header-text .sns-links {
     margin: 20px auto;
     text-align: center;
+    padding-bottom: 15px;
 }
 
 .header-text .sns-links a {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -14,6 +14,7 @@ main {
     height: 100%;
     background-color: rgba(0, 0, 0, 0.4);
     color: rgba(255, 255, 255, 0.9);
+    padding-bottom: 1px;
 }
 
 .header-text .tag-line {
@@ -28,7 +29,6 @@ main {
 .header-text .sns-links {
     margin: 20px auto;
     text-align: center;
-    padding-bottom: 15px;
 }
 
 .header-text .sns-links a {


### PR DESCRIPTION
...f the header

I added this 15px of padding below the social icons in the banner image. I thought it looked a bit better than it being flush against the white line.
