### PR TITLE
Removed protocol from Google fonts link to support HTTPS and HTTP

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,7 +27,7 @@
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}css/main.css" />
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}css/font-awesome.min.css" />
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}css/github.css" />
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400" type="text/css">
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400" type="text/css">
   <link rel="shortcut icon" href="{{ .Site.BaseUrl }}images/favicon.ico" />
   <link rel="apple-touch-icon" href="{{ .Site.BaseUrl }}images/apple-touch-icon.png" />
   <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />


### PR DESCRIPTION
This fixes a browser mixed content warning which will happen when using this template with HTTPS
