### PR TITLE
Enable word wrapping

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,5 +1,6 @@
 main {
     max-width: 750px;
+    word-wrap: break-word;
 }
 
 /* Header */


### PR DESCRIPTION
Thank you for your beautiful template.
I would like you to add `word-wrap` css directive because long texts like url gone out of the display when viewed in smaller devices like smartphone.

---

**no word-wrap**

![word-wrap-1](https://cloud.githubusercontent.com/assets/1954683/7440430/bbeb2568-f0ee-11e4-88e6-06e3f94a65c6.png)

---

**with `word-wrap: break-word;`**
![word-wrap-2](https://cloud.githubusercontent.com/assets/1954683/7440434/d40812d2-f0ee-11e4-8a56-bb26fd06978e.png)
