### PR TITLE
Change LinkedIn url to exclude subdomain

### DIFF
--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -20,7 +20,7 @@
   </a>
   {{ end }}
   {{ with .Site.Params.linkedin }}
-  <a href="https://jp.linkedin.com/in/{{ . }}" target="_blank">
+  <a href="https://linkedin.com/in/{{ . }}" target="_blank">
     <i class="fa fa-linkedin"></i>
   </a>
   {{ end }}


### PR DESCRIPTION
Removed the jp prefix from the linkedin url. Ignore if the jp subdomain is necessary for you and I'll keep this to my fork.
