### PR TITLE
Change stackoverflow param to require user id rather than url

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ copyright = "&copy; Copyright notice"
     github = "Your GitHub username"
     linkedin = "Your LinkedIn username"
     facebook = "Your Facebook username"
-    stackoverflow = "Your Stackoverflow profile"
+    stackoverflow = "Your Stackoverflow user id (number)"
     # Google Analytics API key.
     ga_api_key = "Your Google Analytics tracking id"
     # Mixpanel API key.

--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -15,7 +15,7 @@
   </a>
   {{ end }}
   {{ with .Site.Params.stackoverflow }}
-  <a href="{{ . }}" target="_blank">
+  <a href="https://stackoverflow.com/users/{{ . }}" target="_blank">
     <i class="fa fa-stack-overflow"></i>
   </a>
   {{ end }}


### PR DESCRIPTION
**WARNING: This will break sites (more specifically, the stackoverflow link) that use the old format.**

Why implement it?
Every other param asks for a username, not a full url. Let's be consistent.
