### PR TITLE
Add Google+ link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ copyright = "&copy; Copyright notice"
     twitter = "Your Twitter username"
     github = "Your GitHub username"
     linkedin = "Your LinkedIn username"
+    googleplus = "Your Google+ user id"
     facebook = "Your Facebook username"
     stackoverflow = "Your Stackoverflow profile"
     # Google Analytics API key.

--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -1,7 +1,12 @@
 <div class="sns-links hidden-print">
   {{ with .Site.Params.twitter }}
   <a href="https://twitter.com/{{ . }}" target="_blank">
-      <i class="fa fa-twitter"></i>
+    <i class="fa fa-twitter"></i>
+  </a>
+  {{ end }}
+  {{ with .Site.Params.googleplus }}
+  <a href="https://plus.google.com/+{{ . }}" target="_blank">
+    <i class="fa fa-google"></i>
   </a>
   {{ end }}
   {{ with .Site.Params.facebook }}


### PR DESCRIPTION
Uses `googleplus` parameter and `fa-google` as the icon.
