### PR TITLE
Add contact (email) link

### DIFF
--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -1,4 +1,9 @@
 <div class="sns-links hidden-print">
+  {{ with .Site.Params.contact }}
+  <a href="{{ . }}">
+    <i class="fa fa-envelope"></i>
+  </a>
+  {{ end }}
   {{ with .Site.Params.twitter }}
   <a href="https://twitter.com/{{ . }}" target="_blank">
       <i class="fa fa-twitter"></i>


### PR DESCRIPTION
Adds a contact link to the links section. I don't know how to make this opt-in; I'd imagine that might be desired.

Uses `contact` parameter and `fa-envelope` for the icon.
