### PR TITLE
Improve themecolor implementation

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,9 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
   <meta property="og:title" content="{{ if ne .URL "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}" />
-  {{ with .Site.Params.themecolor }}
-  <meta name="theme-color" content="{{ . }}" />
- {{ end }}
+  <meta name="theme-color" content="{{ if isset .Site.Params "themecolor" }}{{ .Site.Params.themecolor }} {{ else }} #337AB7 {{ end }}"/>
   <meta property="og:site_name" content="{{ .Site.Title }}" />
   <meta property="og:url" content="{{ .Permalink }}" />
   {{ with .Params.images }}{{ range first 5 . }}


### PR DESCRIPTION
Commit 17e0fda adds a default themecolor that complements other colors in Vienna.

A feature I would like to add, but am not sure how to, is changing colors of links and other blue elements using the themecolor parameter.

I know @icecreammatt replaced the blue on your site with brown; can you explain how you did it? I diffed CSS files in [icecreammatt/vienna](https://github.com/icecreammatt/vienna/tree/master/static/css) against the same files in [keichi/vienna](https://github.com/keichi/vienna/tree/master/static/css) and came up empty (there are some differences between the `main.css` files, but they seem irrelevant). Further, I don't see any commits in @icecreammatt's fork that would explain the different coloring.

@icecreammatt @keichi Any help?
