### PR TITLE
Add tags and recent posts to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ copyright = "&copy; Copyright notice"
     # Short subtitle/tagline. This is displayed in the header.
     subtitle = "Short subtitle/tagline of your blog"
     themecolor = "#hexcolor" # Defines the tab color in Chrome for Android.
+    recentPosts = true
+    recentPostDisplayCount = 5
+    tags = true
 ```
 
 ## Usage

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,7 @@
       </div>
       <div class="pull-right">
         {{ range .Params.tags }}
-        <span class="post-tag small"><a href="{{ $baseurl }}/tags/{{ . | urlize }}">#{{ . }}</a></span>
+        <span class="post-tag small"><a href="{{ $baseurl }}tags/{{ . | urlize }}">#{{ . }}</a></span>
         {{ end }}
       </div>
     </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,4 @@
+  {{ partial "sidebar.html" . }}
   </main>
   <footer class="container global-footer">
     <div class="copyright-note pull-left">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -29,7 +29,7 @@
                 <div class="list-group">
                     {{ $baseurl := .Site.BaseURL }}
                     {{ range $name, $value := .Site.Taxonomies.tags }}
-                    <a href="{{ $baseurl }}/tags/{{ $name | urlize }}" class="list-group-item">
+                    <a href="{{ $baseurl }}tags/{{ $name | urlize }}" class="list-group-item">
                         <span class="badge">{{ .Count }}</span>
                         {{ $name }}
                     </a>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,8 +1,8 @@
 <aside>
     <div class="row top-buffer">
 
-      {{ if .Site.Params.RecentPosts }}
-        {{ if and (.Site.Params.RecentPosts) (.Site.Params.Tags) }}
+      {{ if .Site.Params.recentPosts }}
+        {{ if and (.Site.Params.recentPosts) (.Site.Params.tags) }}
           <div class="col-xs-12 col-sm-8 col-md-8">
         {{ else }}
           <div class="col-xs-12 col-sm-12 col-md-12">
@@ -12,7 +12,7 @@
                       <h2 class="panel-title">Recent Posts</h2>
                   </div>
                   <div class="list-group">
-                      {{range first .Site.Params.RecentPostDisplayCount .Site.Pages}}
+                      {{range first .Site.Params.recentPostDisplayCount .Site.Pages}}
                           <a href="{{.RelPermalink}}" class="list-group-item">{{ .Title }}</a>
                       {{ end }}
                   </div>
@@ -20,7 +20,7 @@
           </div>
       {{ end }}
 
-      {{ if .Site.Params.Tags }}
+      {{ if .Site.Params.tags }}
         <div class="col-xs-12 col-sm-4 col-md-4">
             <div class="panel panel-default">
                 <div class="panel-heading">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,43 @@
+<aside>
+    <div class="row top-buffer">
+
+      {{ if .Site.Params.RecentPosts }}
+        {{ if and (.Site.Params.RecentPosts) (.Site.Params.Tags) }}
+          <div class="col-xs-12 col-sm-8 col-md-8">
+        {{ else }}
+          <div class="col-xs-12 col-sm-12 col-md-12">
+        {{ end }}
+              <div class="panel panel-default">
+                  <div class="panel-heading">
+                      <h2 class="panel-title">Recent Posts</h2>
+                  </div>
+                  <div class="list-group">
+                      {{range first .Site.Params.RecentPostDisplayCount .Site.Pages}}
+                          <a href="{{.RelPermalink}}" class="list-group-item">{{ .Title }}</a>
+                      {{ end }}
+                  </div>
+              </div>
+          </div>
+      {{ end }}
+
+      {{ if .Site.Params.Tags }}
+        <div class="col-xs-12 col-sm-4 col-md-4">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h2 class="panel-title">Tags</h2>
+                </div>
+                <div class="list-group">
+                    {{ $baseurl := .Site.BaseURL }}
+                    {{ range $name, $value := .Site.Taxonomies.tags }}
+                    <a href="{{ $baseurl }}/tags/{{ $name | urlize }}" class="list-group-item">
+                        <span class="badge">{{ .Count }}</span>
+                        {{ $name }}
+                    </a>
+                    {{ end }}
+                </div>
+            </div>
+        </div>
+      {{ end }}
+
+    </div>
+</aside>


### PR DESCRIPTION
To enable these add the following to the params in the config.yaml
Tags and Recent post can be enabled independently.

```
params:
    RecentPosts: true
    RecentPostDisplayCount: 5
    Tags: true
```

/cc: @ethanmad 
