### PR TITLE
Fit mobile screen width

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -220,7 +220,7 @@ a.btn-back {
 
 .pagination
 {
-	width: 720px;
+	width: 100%;
 	text-align: center;
 }
 


### PR DESCRIPTION
I've found not to be able to fit the mobile width on my device (iPhone5s)

see
<img src="https://cloud.githubusercontent.com/assets/1933247/11501325/a108ee3a-9876-11e5-81e3-62e06f7a4fdb.PNG" width="200">

Since max-width of main has been already set , I've modified the pagination width to 100%.
