### PR TITLE
.URL deprecated,and .RSSLink deprecated on v 0.55

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
 <head prefix="og: http://ogp.me/ns#">
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-  <meta property="og:title" content="{{ if ne .URL "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}" />
+  <meta property="og:title" content="{{ if ne .Permalink "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}" />
   {{ with .Site.Params.themecolor }}
   <meta name="theme-color" content="{{ . }}" />
  {{ end }}
@@ -26,7 +26,7 @@
   {{ end }}
 
   <title>
-    {{ if ne .URL "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}
+    {{ if ne .Permalink "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}
   </title>
 
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/bootstrap.min.css" />
@@ -36,8 +36,8 @@
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400" type="text/css">
   <link rel="shortcut icon" href="{{ .Site.BaseURL }}images/favicon.ico" />
   <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}images/apple-touch-icon.png" />
-  {{ if eq .URL "/" }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ if eq .Permalink "/" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
   {{ end }}
 </head>
 <body>
@@ -50,13 +50,13 @@
       </div>
       {{ end }}
       {{ partial "link.html" . }}
-      {{ if ne .URL "/" }}
+      {{ if ne .Permalink "/" }}
       <a href="{{ .Site.BaseURL }}" class="btn-header btn-back hidden-xs">
         <i class="fa fa-angle-left" aria-hidden="true"></i>
         &nbsp;Home
       </a>
       {{ end }}
-      {{ with .RSSLink }}
+      {{ with .RelPermalink }}
       <a href="{{ . }}" class="btn-header btn-subscribe hidden-xs">
         <i class="fa fa-rss" aria-hidden="true"></i>
         &nbsp;Subscribe

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,8 +36,8 @@
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400" type="text/css">
   <link rel="shortcut icon" href="{{ .Site.BaseURL }}images/favicon.ico" />
   <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}images/apple-touch-icon.png" />
-  {{ if eq .Permalink "/" }}
-  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ if eq .RelPermalink "/" }}
+  <link href="{{ with .OutputFormats.Get "RSS"  }} {{ .RelPermalink }} {{end}}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
   {{ end }}
 </head>
 <body>
@@ -56,8 +56,8 @@
         &nbsp;Home
       </a>
       {{ end }}
-      {{ with .RelPermalink }}
-      <a href="{{ . }}" class="btn-header btn-subscribe hidden-xs">
+      {{ if .RelPermalink }}
+      <a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }} {{end}}  " class="btn-header btn-subscribe hidden-xs">
         <i class="fa fa-rss" aria-hidden="true"></i>
         &nbsp;Subscribe
       </a>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -3,10 +3,10 @@
   <hr />
 {{ end }}
 {{if .HasPrev}}
-<a class="newer-posts" href="{{ .Prev.URL }}"><span aria-hidden="true">&laquo;</span> Newer Posts</a>
+<a class="newer-posts" href="{{ .Prev.Permalink }}"><span aria-hidden="true">&laquo;</span> Newer Posts</a>
 {{end}}
   <span class="page-number">Page {{ .PageNumber }} of {{.TotalPages}}</span>
 {{if .HasNext}}
-<a class="older-posts" href="{{ .Next.URL }}">Older Posts <span aria-hidden="true">&raquo;</span></a>
+<a class="older-posts" href="{{ .Next.Permalink }}">Older Posts <span aria-hidden="true">&raquo;</span></a>
 {{end}}
 </nav>


### PR DESCRIPTION
There are quite a few changes coming up with hugo v 0.55 

`Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.`

`Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: {{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}.`

this pull request fixes it for you. I just tested your theme and it's working.