### PR TITLE
Fixed next and previous links

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -64,15 +64,15 @@
       {{ end }}
     </section>
     <ul class="pager">
-      {{ if .Next }}
-      <li class="previous"><a href="{{ .Next.Permalink }}"><span aria-hidden="true">&larr;</span> Older</a></li>
-      {{ else }}
-      <li class="previous disabled"><a href="#"><span aria-hidden="true">&larr;</span> Older</a></li>
-      {{ end }}
       {{ if .Prev }}
-      <li class="next"><a href="{{ .Prev.Permalink }}">Newer <span aria-hidden="true">&rarr;</span></a></li>
+      <li class="previous"><a href="{{ .Prev.Permalink }}"><span aria-hidden="true">&larr;</span>Older</a></li>
       {{ else }}
-      <li class="next disabled"><a href="#">Newer <span aria-hidden="true">&rarr;</span></a></li>
+      <li class="previous disabled"><a href="#"><span aria-hidden="true">&larr;</span>Older</a></li>
+      {{ end }}
+      {{ if .Next }}
+      <li class="next"><a href="{{ .Next.Permalink }}">Newer<span aria-hidden="true">&rarr;</span></a></li>
+      {{ else }}
+      <li class="next disabled"><a href="#">Newer<span aria-hidden="true">&rarr;</span></a></li>
       {{ end }}
     </ul>
   </footer>


### PR DESCRIPTION
As mentioned in issue #37 this fixes the reverse order of the previous and next buttons on single content pages.

Closes #37